### PR TITLE
Scan trigger

### DIFF
--- a/noble/node-red-contrib-noble.html
+++ b/noble/node-red-contrib-noble.html
@@ -66,6 +66,8 @@
         <li>The <b>msg.payload</b> will be empty in this case to prevent mistreating status messages as BLE detection messages.</li>
     </ul>
 
+    <p>The node will begin scanning after its deployed, and will not stop until it is deployed again.  It can be useful to turn on and off scanning to conserve energy and force scan requests to be sent triggering devices to respond.  To control scanning, send a message containing <code>msg.scan=false</code> to turn off scanning, and <code>msg.scan=true</code> to turn it on.</p>
+
     <p>The <b>msg.payload</b> will contain the <i>peripheral uuid</i> and the <i>local name</i> of the BLE device detected.</p>
     <p>Additionally it will set the following values:</p>
     <ul>
@@ -100,7 +102,7 @@
             duplicates: {value:false},
             name: {value:""}
         },
-        inputs:0,               // set the number of inputs - only 0 or 1
+        inputs:1,               // set the number of inputs - only 0 or 1
         outputs:1,              // set the number of outputs - 0 to n
         // set the icon (held in icons dir below where you save the node)
         icon: "bluetooth.png",     // saved in  icons/myicon.png

--- a/noble/node-red-contrib-noble.js
+++ b/noble/node-red-contrib-noble.js
@@ -159,6 +159,16 @@ module.exports = function(RED) {
 
             node.warn('Unable to start BLE scan. Adapter state: ' + noble.state);
         }
+
+        // control scanning
+        node.on('input', function (msg) {
+            if (msg.scan && msg.scan === true) {
+                startScan(false, false);
+            } else if (msg.scan === false) {
+                stopScan(false, false);
+            }
+        });
+
     
         node.on("close", function() {
             // Called when the node is shutdown - eg on redeploy.
@@ -169,13 +179,6 @@ module.exports = function(RED) {
             noble.removeAllListeners();
         });
 
-        //noble.on('scanStart', function() {
-        //    node.debug("Scan of BLEs started");
-        //});
-        //
-        //noble.on('scanStop', function() {
-        //    node.debug("Scan of BLEs stopped");
-        //});
     }
     
     // Register the node by name. This must be called before overriding any of the

--- a/noble/node-red-contrib-noble.js
+++ b/noble/node-red-contrib-noble.js
@@ -20,10 +20,9 @@
  * @author <a href="mailto:carlos.pedrinaci@open.ac.uk">Carlos Pedrinaci</a> (KMi - The Open University)
  * based on the initial node by Charalampos Doukas http://blog.buildinginternetofthings.com/2013/10/12/using-node-red-to-scan-for-ble-devices/
  */
-
 module.exports = function(RED) {
-
     "use strict";
+
     var noble = require('noble');
     var os = require('os');
     
@@ -90,7 +89,6 @@ module.exports = function(RED) {
         // Take care of starting the scan and sending the status message
         function startScan(stateChange, error) {
             if (!node.scanning) {
-                node.scanning = true;
                 // send status message
                 var msg = {
                     statusUpdate: true,
@@ -100,15 +98,17 @@ module.exports = function(RED) {
                 };
                 node.send(msg);
                 // start the scan
-                noble.startScanning(node.uuids, node.duplicates);
-                node.log("Scanning for BLEs started. UUIDs: " + node.uuids + " - Duplicates allowed: " + node.duplicates);
+                noble.startScanning(node.uuids, node.duplicates, function() {
+                    node.log("Scanning for BLEs started. UUIDs: " + node.uuids + " - Duplicates allowed: " + node.duplicates);
+                    node.status({fill:"green",shape:"dot",text:"started"});
+                    node.scanning = true;
+                });
             }
         }
 
         // Take care of stopping the scan and sending the status message
         function stopScan(stateChange, error) {
             if (node.scanning) {
-                node.scanning = false;
                 // send status message
                 var msg = {
                     statusUpdate: true,
@@ -117,12 +117,14 @@ module.exports = function(RED) {
                     state: noble.state
                 };
                 node.send(msg);
-                // start the scan
-                noble.stopScanning();
+                // stop the scan
+                noble.stopScanning(function() {
+                    node.log('BLE scanning stopped.');
+                    node.status({fill:"red",shape:"ring",text:"stopped"});
+                    node.scanning = false;
+                });
                 if (error) {
                     node.warn('BLE scanning stopped due to change in adapter state.');
-                } else {
-                    node.info('BLE scanning stopped.');
                 }
             }
         }
@@ -158,11 +160,13 @@ module.exports = function(RED) {
             node.warn('Unable to start BLE scan. Adapter state: ' + noble.state);
         }
     
-        this.on("close", function() {
+        node.on("close", function() {
             // Called when the node is shutdown - eg on redeploy.
             // Allows ports to be closed, connections dropped etc.
             // eg: this.client.disconnect();
             stopScan(false, false);
+            // remove listeners since they get added again on deploy
+            noble.removeAllListeners();
         });
 
         //noble.on('scanStart', function() {


### PR DESCRIPTION
This adds feature #1 and incorporates fix #6.  Added an input to the node that accepts messages to turn scanning on and off.  This way, can scan periodically using the inject node for example. To control scanning, send a message containing msg.scan=false to turn off scanning, and msg.scan=true to turn it on.
